### PR TITLE
fix: do not specify organization id in request

### DIFF
--- a/update-3dcs-usage.py
+++ b/update-3dcs-usage.py
@@ -42,7 +42,8 @@ PW_API_KEY = os.environ.get('PW_API_KEY')
 HEADERS = {"Authorization": "Basic {}".format(encode_string_to_base64(os.environ['PW_API_KEY']))}
 
 GROUP_NAME: str = '3dcs-run-hours'
-ORGANIZATION_URL: str = f'https://{PW_PLATFORM_HOST}/api/v2/organization/teams?organization={CUSTOMER_ORG_ID}'
+#ORGANIZATION_URL: str = f'https://{PW_PLATFORM_HOST}/api/v2/organization/teams?organization={CUSTOMER_ORG_ID}'
+ORGANIZATION_URL: str = f'https://{PW_PLATFORM_HOST}/api/v2/organization/teams'
 
 CONNECTED_WORKERS = {}
 

--- a/update-3dcs-usage.py
+++ b/update-3dcs-usage.py
@@ -90,7 +90,8 @@ def update_group_allocation_used(group_id, allocation_used):
     return http_put_sync(url, payload)
 
 def get_group_id(group_name):
-    url = f'https://{PW_PLATFORM_HOST}/api/v2/organization/teams?organization={CUSTOMER_ORG_ID}'
+    #url = f'https://{PW_PLATFORM_HOST}/api/v2/organization/teams?organization={CUSTOMER_ORG_ID}'
+    url = f'https://{PW_PLATFORM_HOST}/api/v2/organization/teams'
 
     res = requests.get(url, headers = get_headers())
 


### PR DESCRIPTION
This change is in response to a change in the API.